### PR TITLE
docs:タイトルの修正、英語の場合飛び出さないように修正及び、余白を持たせるように変更 #51

### DIFF
--- a/app/views/boards/_board.html.erb
+++ b/app/views/boards/_board.html.erb
@@ -7,7 +7,7 @@
         <div class="pr-2 pt-2"><%= board.progress.name %></div>
       </div>
       <div class="mx-auto my-auto">
-        <h1 class="text-3xl"><%= board.title %></h1>
+        <h1 class="break-all text-3xl m-2"><%= board.title %></h1>
       </div>
       <div class="flex justify-between place-items-end">
         <div class="flex flex-col">


### PR DESCRIPTION
boardタイトルの修正、余白を持たせるように変更。
おまけで、英語の場合飛び出さないように修正しました。