### PR TITLE
重複したカテゴリと進捗度のレコードを削除#49

### DIFF
--- a/db/migrate/20230511170038_reset_categories_and_progresses.rb
+++ b/db/migrate/20230511170038_reset_categories_and_progresses.rb
@@ -1,0 +1,9 @@
+class ResetCategoriesAndProgresses < ActiveRecord::Migration[7.0]
+  def up
+    Category.where(id: [5, 6, 7, 8]).delete_all
+    Progress.where(id: [5, 6, 7, 8]).delete_all
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_29_081752) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_11_170038) do
   create_table "boards", force: :cascade do |t|
     t.string "title", null: false
     t.text "body", null: false


### PR DESCRIPTION
記事作成時の、進捗度とカテゴリが重複してるのを修正しました。
マグレーションファイルで削除しました。
seedデータをデプロイの度に実行しないようにentrypoint.shを修正しました。